### PR TITLE
remove JUnit packages from module-info.java

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -1,18 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="src" path="resources"/>
-	<classpathentry kind="src" path="test"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/5">
+	<classpathentry kind="src" output="bin/main" path="src"/>
+	<classpathentry kind="src" output="bin/main" path="resources"/>
+	<classpathentry kind="src" output="bin/test" path="test">
 		<attributes>
-			<attribute name="module" value="true"/>
+			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/5"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.USER_LIBRARY/JavaFX21">
 		<attributes>
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/jdk-21.0.2"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21/">
+		<attributes>
+			<attribute name="module" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="output" path="bin/solitaire"/>
 </classpath>

--- a/src/module-info.java
+++ b/src/module-info.java
@@ -21,8 +21,6 @@
 module solitaire {
 	requires javafx.controls;
 	requires transitive javafx.graphics;
-	requires static org.junit.jupiter.api;
-	requires static org.junit.jupiter.params;
 	exports ca.mcgill.cs.stg.solitaire.gui;
 	exports ca.mcgill.cs.stg.solitaire.cards;
 }


### PR DESCRIPTION
JUnit packages are now removed from `module-info.java`, as they are for unit tests only, and not for the main application.

The `.classpath` file is updated to separate the application's module path from the test code's classpath, and they are compiled to separate class folders, as required by Eclipse.

Fixes #29 
